### PR TITLE
Use LDLIBS to specify linker maths library.

### DIFF
--- a/DistributedChaffinMethod/Makefile
+++ b/DistributedChaffinMethod/Makefile
@@ -1,5 +1,6 @@
 CC=gcc
-CFLAGS = -O3 -lm
+CFLAGS = -O3
+LDLIBS = -lm
 
 all: DistributedChaffinMethod
 


### PR DESCRIPTION
This ensures the `-lm` is placed at the end of the compile recipe, which
prevents compilation failures with `undefined reference to 'exp'` on some systems.

Tested on Ubuntu 19.04.